### PR TITLE
Added github repo to dist metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Perl module Text::MacroScript
 
 2.07    2015-05-??
     Other
+    * Added the github repo to the dist metadata
     * Added the min perl version (5.010) in the dist metadata
     * Added the license as LGPL (GNU Lesser General Public License, Version 2.1)
       in the dist metadata.

--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for Perl module Text::MacroScript
 2.07    2015-05-??
     Other
     * Added the min perl version (5.010) in the dist metadata
+    * Added the license as LGPL (GNU Lesser General Public License, Version 2.1)
+      in the dist metadata.
 
 2.06	2015-05-16
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+Revision history for Perl module Text::MacroScript
+
+2.07    2015-05-??
+    Other
+    * Added the min perl version (5.010) in the dist metadata
+
 2.06	2015-05-16
 
 	Bug Fixes

--- a/MacroScript.pm
+++ b/MacroScript.pm
@@ -9,7 +9,7 @@ use Carp qw( carp croak );
 use Path::Tiny;
 
 use vars qw( $VERSION );
-$VERSION = '2.06'; 
+$VERSION = '2.07'; 
 
 use Object::Tiny::RW 
 	'comment',			# True to create the %%[] comment macro

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,4 +45,18 @@ WriteMakefile(
 
     ($mm_ver >= 6.31 ? (LICENSE => 'lgpl_2_1') : ()),
 
+    ($mm_ver <= 6.45
+        ? ()
+        : (META_MERGE => {
+            'meta-spec' => { version => 2 },
+            resources => {
+                repository  => {
+                    type => 'git',
+                    web  => 'https://github.com/pauloscustodio/Text-MacroScript/issues',
+                    url  => 'https://github.com/pauloscustodio/Text-MacroScript/issues.git',
+                },
+            },
+          })
+    ),
+
 ) ;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,13 @@ use warnings;
 use ExtUtils::MakeMaker;
 require v5.10;
 
+my $mm_ver = $ExtUtils::MakeMaker::VERSION;
+if ($mm_ver =~ /_/) {
+    # developer release
+    $mm_ver = eval $mm_ver;
+    die $@ if $@;
+}
+
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 
@@ -30,4 +37,10 @@ WriteMakefile(
 		'macrodir',
 	],
     'dist'         => { COMPRESS => "gzip -9", SUFFIX => "gz" }
+
+    ($mm_ver >= 6.48
+        ? (MIN_PERL_VERSION => 5.01)
+        : ()
+    ),
+
 ) ;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,11 +36,13 @@ WriteMakefile(
 		'macropp',
 		'macrodir',
 	],
-    'dist'         => { COMPRESS => "gzip -9", SUFFIX => "gz" }
+    'dist'         => { COMPRESS => "gzip -9", SUFFIX => "gz" },
 
     ($mm_ver >= 6.48
         ? (MIN_PERL_VERSION => 5.01)
         : ()
     ),
+
+    ($mm_ver >= 6.31 ? (LICENSE => 'lgpl_2_1') : ()),
 
 ) ;


### PR DESCRIPTION
Hi Paulo,

The main purpose for this PR is to add the github repo to the dist metadata. With that, the repo will be linked in the sidebar on MetaCPAN, and various tools can find it. That will also make the dist a candidate for assigning in the [CPAN Pull Request Challenge](http://cpan-prc.org).

The other changes should get you [CPANTS clean](http://cpants.cpanauthors.org/author/PSCUST) (since you can't affect the other flag -- only someone else using your module in their CPAN module can do that).

Cheers,
Neil
