### PR TITLE
fix errors for perl 5.37.x

### DIFF
--- a/lib/Text/MacroScript.pm
+++ b/lib/Text/MacroScript.pm
@@ -223,7 +223,7 @@ DESTROY {
 	my($self) = @_;
 	if (@{$self->context}) {
 		my $context = $self->_last_context;
-		$self->line_nr( $context->start_line_nr );
+		$self->line_nr( $context ? $context->start_line_nr : "unknown" );
 		$self->_error("Unbalanced open structure at end of file");
 	}
 }

--- a/lib/Text/MacroScript.pm
+++ b/lib/Text/MacroScript.pm
@@ -785,6 +785,7 @@ sub _eval_expression {
 		elsif (! $ignore_errors) {
 			my $error = $@;
 			$error =~ s/ at \(eval.*//;
+                        $error =~ s/^Execution of .* aborted due to compilation errors.\n//m;
 			$self->_error("Eval error: $error");
 		}
 	}


### PR DESCRIPTION
In modern perls when an eval dies due to compile errors it will consistently add the text "Execution of ... aborted due to compilation errors." to the error message. This fixes the tests in this package to deal with this. It also fixes a bug in cleanup where start_line_nr() was being called on an undefined value.

See https://github.com/Perl/perl5/issues/20864
